### PR TITLE
Give agentic agents a T&E-sized timeout budget

### DIFF
--- a/translate.sh
+++ b/translate.sh
@@ -25,6 +25,17 @@ api_key = "$OPEN_ROUTER_API_KEY"
 backend = "openrouter"
 model = "openai/gpt-5.3-codex"
 max_tokens = 16384
+
+# The T&E runs against a much larger, unknown codebase (~100 kloc); a ~75 kloc
+# translation took roughly 7 hours. The in-repo defaults (2h translate / 90m
+# verify) are sized for small benchmarks, so the agentic agents need a far more
+# generous wall-clock budget here. These are the external-timeout caps in
+# seconds; overshooting is preferable to a premature kill.
+[tools.translate_agentic]
+timeout_secs = 43200   # 12h
+
+[tools.verify_fix_agentic]
+timeout_secs = 28800   # 8h
 EOF
 
 translate -f -o $2 $1


### PR DESCRIPTION
## Why

The T&E runs against a much larger, unknown codebase (~100 kloc). A ~75 kloc translation (zlib) took roughly 7 hours. HARVEST's in-repo agentic timeouts are intentionally sized for small benchmarks:

- `tools.translate_agentic.timeout_secs = 7200` (2h)
- `tools.verify_fix_agentic.timeout_secs = 5400` (90m)

Those would kill a real T&E translation long before it finishes.

## What

Append generous agentic timeout caps to the `translate.toml` the container writes, so the deployment overrides the modest in-repo defaults:

- `tools.translate_agentic.timeout_secs = 43200` (12h)
- `tools.verify_fix_agentic.timeout_secs = 28800` (8h)

These are plain config keys read by `harvest_translate` (they layer over the embedded `default_config.toml`), so no code change is required - just larger values in the container config. The corresponding regression test that locks the override contract is UW-HARVEST/harvest#175.

Overshooting is preferable to a premature kill; tune down once we have real timing data on the T&E corpus.

## Note

This only sets the budget. It does not by itself switch the container onto the agentic Claude path (still kiro + OpenRouter LLM tools here); that broader container adaptation - agentic invocation and Anthropic-API key auth - is tracked separately.