### PR TITLE
Migrate container to the agentic Claude translation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,20 @@ $ docker build -t harvest/harvest .
 
 ## Features
 
-WIP
+This image runs HARVEST's agentic translation pipeline, driving Claude
+(via the Anthropic API) to translate the C source project to Rust and
+then verify and repair the result. HARVEST is pinned to a specific
+commit and built from source against a pinned nixpkgs (see
+`default.nix`), and the `claude` CLI and a Rust toolchain are provided
+on the agent's PATH so it can build and test the translated crate.
 
-This "translation" image does not translation whatsoever. It merely
-copies the source project to a `orig` subdirectory in the output, and
-initializes an empty Rust/Cargo binary alongside it so the test
-infrastructure has _something_ to compile.
+## Authentication
+
+Claude runs headless against the Anthropic API; there is no interactive
+login. Provide the API key as an environment variable:
+
+- `ANTHROPIC_API_KEY` -- required. The entry point exits immediately if
+  it is unset.
 
 ## Interface expected by TRACTOR runner:
 
@@ -29,6 +37,9 @@ The container must expect the following environment:
 
 - $newuid and $newgid environment variables denoting the owner user
   and group that the output should belong to.
+
+- `ANTHROPIC_API_KEY` set to a key with enough rate/usage headroom for a
+  multi-hour run (a ~100 kloc translation can take many hours).
 
 - A current-working-directory `/usr/c2rust_execution`
 

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,12 @@
 # Pin nixpkgs so the T&E image is reproducible regardless of the channel the
 # base image happens to ship. Bump the rev/hash together when updating.
-# allowUnfree is required because claude-code ships under an unfree license.
+# This is a pinned nixpkgs-unstable rev: it ships claude-code 2.1.154, which
+# defaults to the latest Opus (claude-opus-4-8); the 25.11/26.05 stable
+# channels still default to opus-4-7. allowUnfree is required because
+# claude-code is distributed under an unfree license.
 { pkgs ? import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/25f538306313eae3927264466c70d7001dcea1df.tar.gz";
-    sha256 = "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=";
+    url = "https://github.com/NixOS/nixpkgs/archive/e9a7635a57597d9754eccebdfc7045e6c8600e6b.tar.gz";
+    sha256 = "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=";
   }) { config.allowUnfree = true; } }:
 
 let

--- a/default.nix
+++ b/default.nix
@@ -1,64 +1,60 @@
-{ pkgs ? import <nixpkgs> { }}:
+# Pin nixpkgs so the T&E image is reproducible regardless of the channel the
+# base image happens to ship. Bump the rev/hash together when updating.
+{ pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/25f538306313eae3927264466c70d7001dcea1df.tar.gz";
+    sha256 = "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=";
+  }) { } }:
 
 let
+  # The HARVEST translation binary. Pinned to a specific commit on main and
+  # built against the same pinned nixpkgs as everything else.
+  harvest-code = import (pkgs.fetchFromGitHub {
+    owner = "UW-HARVEST";
+    repo = "harvest";
+    rev = "5214d76c0f017b7a0ccf8231bcaa83f0ee911281";
+    hash = "sha256-IBihlttfGzNcLoSeIC+K9N1nbpNnjHHNvXu0Sc57mWE=";
+  }) { inherit pkgs; };
+
+  # Tools the agentic Claude agent invokes from its own shell while it builds
+  # and tests the translated crate. (HARVEST's own C parsing happens inside the
+  # `translate` binary, which harvest-code already wraps with CLANG_PATH.)
+  agentRuntime = [
+    pkgs.cargo
+    pkgs.rustc
+    pkgs.gcc            # provides `cc`, the linker rustc drives
+    pkgs.binutils
+    pkgs.pkg-config
+    pkgs.git
+    pkgs.cacert         # TLS roots for cargo fetches and the Anthropic API
+    pkgs.coreutils-full # provides `timeout`, the agent budget wrapper
+  ];
+
   translate = pkgs.stdenv.mkDerivation rec {
     name = "harvest-translation";
     src = ./.;
-    buildInputs = [
-      harvest-code
-      kiro-cli
-      pkgs.coreutils-full
-    ];
-    nativeBuildInputs = [
-      pkgs.makeWrapper
-    ];
-    PATH = pkgs.lib.makeBinPath buildInputs;
+    buildInputs = [ harvest-code pkgs.claude-code ] ++ agentRuntime;
+    nativeBuildInputs = [ pkgs.makeWrapper ];
     installPhase = ''
       mkdir -p $out/bin
       cp $src/translate.sh $out/bin/translate-wrapper
-      wrapProgram $out/bin/translate-wrapper --prefix PATH : ${pkgs.lib.makeBinPath buildInputs }
-    '';
-  };
-  harvest-code = import (pkgs.fetchFromGitHub {
-      owner = "UW-Harvest";
-      repo = "harvest";
-      rev = "april15te";
-      hash = "sha256-04YKZolqV8znxwlPVJBpKXnFsZogekmGkywGefrh4XQ=";
-  }) {};
-  kiro-cli = pkgs.stdenv.mkDerivation rec {
-    name = "kiro-cli";
-    src = builtins.fetchTarball {
-      url = "https://prod.download.cli.kiro.dev/stable/1.29.6/kirocli-x86_64-linux-musl.tar.gz";
-      sha256 = "079c583ilcrgvladccivgcw0pa6jmqmfkgg37034qd6ckqmkipnl";
-    };
-    buildInputs = [
-    ];
-    nativeBuildInputs = [
-      pkgs.makeWrapper
-    ];
-    PATH = pkgs.lib.makeBinPath buildInputs;
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src/bin/* $out/bin/
-      wrapProgram $out/bin/kiro-cli --set OPENSSL_DIR "${pkgs.openssl.dev}";
-      wrapProgram $out/bin/kiro-cli-chat --set OPENSSL_DIR "${pkgs.openssl.dev}";
+      wrapProgram $out/bin/translate-wrapper \
+        --prefix PATH : ${pkgs.lib.makeBinPath buildInputs} \
+        --set SSL_CERT_FILE "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
     '';
   };
 in pkgs.stdenv.mkDerivation rec {
-    name = "s3_wrapper";
-    src = ./.;
-    buildInputs = [
-      translate (pkgs.python3.withPackages (p: [ p.boto3 ]))
-      pkgs.openssl
-      pkgs.openssl.dev
-      pkgs.pkg-config
-    ];
-    nativeBuildInputs = [
-      pkgs.makeWrapper
-    ];
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src/s3_wrapper.py $out/bin/s3_wrapper.py
-      wrapProgram $out/bin/s3_wrapper.py --prefix PATH : ${pkgs.lib.makeBinPath buildInputs }
-    '';
-  }
+  name = "s3_wrapper";
+  src = ./.;
+  buildInputs = [
+    translate
+    (pkgs.python3.withPackages (p: [ p.boto3 ]))
+    pkgs.coreutils-full
+  ];
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/s3_wrapper.py $out/bin/s3_wrapper.py
+    chmod +x $out/bin/s3_wrapper.py
+    wrapProgram $out/bin/s3_wrapper.py --prefix PATH : ${pkgs.lib.makeBinPath buildInputs}
+  '';
+}

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
 # Pin nixpkgs so the T&E image is reproducible regardless of the channel the
 # base image happens to ship. Bump the rev/hash together when updating.
+# allowUnfree is required because claude-code ships under an unfree license.
 { pkgs ? import (builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/25f538306313eae3927264466c70d7001dcea1df.tar.gz";
     sha256 = "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=";
-  }) { } }:
+  }) { config.allowUnfree = true; } }:
 
 let
   # The HARVEST translation binary. Pinned to a specific commit on main and

--- a/translate.sh
+++ b/translate.sh
@@ -1,36 +1,34 @@
 #!/bin/sh
+#
+# Entry point for the agentic Claude translation path.
+#
+# Invoked as: translate-wrapper <source-dir> <output-dir>
+#
+# Required environment:
+#   ANTHROPIC_API_KEY  Claude authenticates against the Anthropic API with this
+#                      key (no interactive login). Provided to the container by
+#                      the T&E runner.
+#   newuid / newgid    Owner the output should belong to (set by the runner).
 
-mkdir -p ~/.local/share/kiro-cli/
-wget -O ~/.local/share/kiro-cli/data.sqlite3 "$KIRO_CREDENTIAL_FILE"
+# Claude reads ANTHROPIC_API_KEY from the environment; fail fast if it is absent
+# rather than dropping into an interactive login that cannot succeed headless.
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+    echo "translate-wrapper: ANTHROPIC_API_KEY is not set; the agentic Claude" \
+         "path cannot authenticate." >&2
+    exit 1
+fi
 
-mkdir -p ~/.config/harvest
-cat > ~/.config/harvest/translate.toml <<EOF
-[tools.raw_source_to_cargo_llm]
-address = ""
-api_key = "$OPEN_ROUTER_API_KEY"
-backend = "openrouter"
-model = "openai/gpt-5.3-codex"
-max_tokens = 16384
+# The agent (cargo, claude config, HARVEST config) needs a writable HOME, and
+# cando2's AF_UNIX socket path is capped at 108 bytes, so keep TMPDIR short.
+export HOME="${HOME:-/tmp/harvest-home}"
+export TMPDIR=/tmp
+mkdir -p "$HOME"
 
-[tools.modular_translation_llm]
-address = ""
-api_key = "$OPEN_ROUTER_API_KEY"
-backend = "openrouter"
-model = "openai/gpt-5.3-codex"
-max_tokens = 16384
-
-[tools.fix_declarations_llm]
-address = ""
-api_key = "$OPEN_ROUTER_API_KEY"
-backend = "openrouter"
-model = "openai/gpt-5.3-codex"
-max_tokens = 16384
-
-# The T&E runs against a much larger, unknown codebase (~100 kloc); a ~75 kloc
-# translation took roughly 7 hours. The in-repo defaults (2h translate / 90m
-# verify) are sized for small benchmarks, so the agentic agents need a far more
-# generous wall-clock budget here. These are the external-timeout caps in
-# seconds; overshooting is preferable to a premature kill.
+# Deployment config: give the agentic agents a T&E-sized budget. ~100 kloc
+# inputs can run for many hours, so override the modest in-repo defaults (2h
+# translate / 90m verify). These are plain config keys read by harvest_translate.
+mkdir -p "$HOME/.config/harvest"
+cat > "$HOME/.config/harvest/translate.toml" <<EOF
 [tools.translate_agentic]
 timeout_secs = 43200   # 12h
 
@@ -38,5 +36,5 @@ timeout_secs = 43200   # 12h
 timeout_secs = 28800   # 8h
 EOF
 
-translate -f -o $2 $1
-chown -R $newuid:$newgid $2/*
+translate --agentic --agentic-verify --agentic-agent claude -f -o "$2" "$1"
+chown -R "$newuid:$newgid" "$2"/*

--- a/translate.sh
+++ b/translate.sh
@@ -24,6 +24,11 @@ export HOME="${HOME:-/tmp/harvest-home}"
 export TMPDIR=/tmp
 mkdir -p "$HOME"
 
+# Claude Code refuses --permission-mode bypassPermissions as root unless it is
+# told it is running in a recognized sandbox. This image runs as root in an
+# ephemeral, isolated T&E container, which is exactly that, so signal it.
+export IS_SANDBOX=1
+
 # Deployment config: give the agentic agents a T&E-sized budget. ~100 kloc
 # inputs can run for many hours, so override the modest in-repo defaults (2h
 # translate / 90m verify). These are plain config keys read by harvest_translate.


### PR DESCRIPTION
## Why

The image runs HARVEST's translation pipeline for the T&E, but it was wired to the **non-agentic** OpenRouter LLM path driven by `kiro-cli`. The T&E plan is to run the **agentic Claude** pipeline, authenticated against the Anthropic API via a key provided as a container env var.

## What

**`default.nix`**
- Pin **nixpkgs** via `fetchTarball` so the image is reproducible regardless of the base image's channel. The rev is a pinned **nixpkgs-unstable** that ships `claude-code` **2.1.154**, whose default model is the latest Opus (**claude-opus-4-8**); the 25.11/26.05 stable channels still default to opus-4-7.
- `config.allowUnfree = true` on the pinned import -- `claude-code` is distributed under an unfree license, so a clean nixpkgs refuses to evaluate it.
- Bump **harvest-code** from `april15te` to current `main` (`5214d76`), built against the pinned nixpkgs (rustc 1.95, clang 21).
- Drop **kiro-cli**; add **`pkgs.claude-code`** (provides the `claude` binary).
- Put a **Rust toolchain** (`cargo`, `rustc`, `gcc`, `binutils`, `pkg-config`), `git`, `cacert`, and `coreutils-full` on the wrapper's PATH so the agent's own shell can build and test the translated crate (it previously had none of these), and set `SSL_CERT_FILE` for cargo fetches and Anthropic API TLS.

**`translate.sh`**
- Authenticate Claude headless via **`ANTHROPIC_API_KEY`**; fail fast if unset (no interactive login).
- `export IS_SANDBOX=1` -- Claude Code refuses `--permission-mode bypassPermissions` as root unless it is told it is in a recognized sandbox; this image runs as root in an ephemeral, isolated T&E container.
- Set a writable `HOME` and short `TMPDIR=/tmp` (cando2's AF_UNIX socket 108-byte limit).
- Invoke `translate --agentic --agentic-verify --agentic-agent claude -f -o "$2" "$1"`.
- Keep the T&E-sized timeout overrides (12h translate / 8h verify).

**`README.md`** -- document the agentic path and the `ANTHROPIC_API_KEY` requirement.

## Validation

Built the image with `docker build` on the actual `nixos/nix` base (not just a host with global nixpkgs config -- that is what surfaced the `allowUnfree` and root-guard issues). Confirmed the built image bakes in `claude-code` 2.1.154 with `claude-opus-4-8` as the default model.

Ran the full chain end-to-end inside the container against a minimal CMake project: `s3_wrapper.py` -> `translate-wrapper` -> `translate` (whole pipeline) -> `claude`, which authenticates via `ANTHROPIC_API_KEY` (`apiKeySource: ANTHROPIC_API_KEY`) in `bypassPermissions` mode and reaches the Anthropic API. A live key-authenticated translation smoke run was also exercised.

## Notes

- `translate` requires a `CMakeLists.txt` with an `add_executable(` / `add_library(` line to determine the project kind; a bare source file fails `build_project_spec`. T&E inputs are CMake projects, so this is expected.
- `Dockerfile` is unchanged (env vars are runtime). `docker.nix` (a stale `dockerTools` alternate that builds a no-op translate) is left as-is.
- The API key needs rate/usage headroom for a multi-hour run; the TRACTOR runner's own container wall-clock (if any) should exceed the 12h/8h budgets.