### PR TITLE
Handle the T&E parent-directory input layout

### DIFF
--- a/translate.sh
+++ b/translate.sh
@@ -41,5 +41,19 @@ timeout_secs = 43200   # 12h
 timeout_secs = 28800   # 8h
 EOF
 
-translate --agentic --agentic-verify --agentic-agent claude -f -o "$2" "$1"
+# The T&E hands us a parent directory whose actual C project lives in a
+# `test_case/` subdirectory, alongside a top-level CMakeLists.txt that only does
+# `add_subdirectory(test_case)`, an optional CMakePresets.json, and an optional
+# `tests/` harness. HARVEST translates the C project, and its build_config /
+# build_project_spec stages look for configuration.json and the
+# add_executable/add_library CMakeLists at the root of what they are given -- so
+# point them at test_case/. Inputs that already are the project (no test_case/
+# child, as in the older corpus) are used unchanged.
+src="$1"
+if [ -d "$src/test_case" ]; then
+    src="$src/test_case"
+    echo "translate-wrapper: input has a test_case/ child; translating '$src'." >&2
+fi
+
+translate --agentic --agentic-verify --agentic-agent claude -f -o "$2" "$src"
 chown -R "$newuid:$newgid" "$2"/*


### PR DESCRIPTION
## Why

The T&E hands the container a **parent directory** whose actual C project lives in a `test_case/` subdirectory, alongside:
- a top-level `CMakeLists.txt` that only does `add_subdirectory(test_case)`,
- an optional `CMakePresets.json`,
- an optional `tests/` harness (clar).

This is the layout in `example_P02` and how sphincs is organized. HARVEST's early stages look for `configuration.json` and the `add_executable(`/`add_library(` `CMakeLists.txt` at the **root** of what they are handed:

- `build_config`'s scanner reads `configuration.json` from the root; in the parent layout it lives in `test_case/`, so the scanner emits an **empty** `BuildConfigIR`.
- `build_project_spec` then falls back to the legacy matcher on the **root** `CMakeLists.txt`, which only contains `add_subdirectory(test_case)` -- no target -- and fails with **`Could not identify project kind from CMakeLists.txt`**.

Reproduced locally with the `translate` binary against the parent dir (fails) vs. the `test_case` dir (succeeds: `ProjectSpec(kind=Executable)`), across all four `example_P02` variants (`config_tests`, `config_notests`, `noconfig_tests`, `noconfig_notests`).

## What

In `translate.sh`, descend into `test_case/` when the input has such a child, before invoking `translate`. Inputs that already are the project (no `test_case/` child, as in the older corpus) are used unchanged, so this is backward compatible.

`test_case/` is self-contained for translation: its own `CMakeLists.txt` holds the real targets and the configurable-variable logic, and `configuration.json` sits at its root -- so the configurable-build feature keeps working. The top-level `CMakeLists.txt`/`CMakePresets.json` are CMake scaffolding HARVEST does not consume, and `tests/` is the verification harness (a separate follow-up will wire those clar tests into the verify stage).

## Validation

- `sh -n` clean; the descend snippet resolves parent -> `test_case`, leaves an already-project input unchanged.
- The local `translate` binary advances past `build_project_spec` to translation for the resolved `test_case` dir on every `example_P02` variant.

Runtime-only change (the script copied into the image); no `default.nix`/image rebuild required. The agentic chain itself was already validated end-to-end in PR #3.