### PR TITLE
Enable the clar test oracle for the June T&E

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,13 +10,14 @@
   }) { config.allowUnfree = true; } }:
 
 let
-  # The HARVEST translation binary. Pinned to a specific commit on main and
-  # built against the same pinned nixpkgs as everything else.
+  # The HARVEST translation binary. Pinned to the june-te branch (the June T&E
+  # experiment, which adds the optional clar test oracle) and built against the
+  # same pinned nixpkgs as everything else.
   harvest-code = import (pkgs.fetchFromGitHub {
     owner = "UW-HARVEST";
     repo = "harvest";
-    rev = "5214d76c0f017b7a0ccf8231bcaa83f0ee911281";
-    hash = "sha256-IBihlttfGzNcLoSeIC+K9N1nbpNnjHHNvXu0Sc57mWE=";
+    rev = "be32b794a95ff880533db4c46093d54165b6295c";
+    hash = "sha256-Sl6x1LUKNpnwVNiacg4s603gRw5YIaUXbHKdDuxS5Rg=";
   }) { inherit pkgs; };
 
   # Tools the agentic Claude agent invokes from its own shell while it builds
@@ -28,6 +29,9 @@ let
     pkgs.gcc            # provides `cc`, the linker rustc drives
     pkgs.binutils
     pkgs.pkg-config
+    pkgs.cmake          # the clar harness (and many C projects) build via CMake
+    pkgs.gnumake        # cmake's default generator backend
+    pkgs.python3        # clar's generate.py emits the test suite
     pkgs.git
     pkgs.cacert         # TLS roots for cargo fetches and the Anthropic API
     pkgs.coreutils-full # provides `timeout`, the agent budget wrapper

--- a/default.nix
+++ b/default.nix
@@ -42,6 +42,10 @@ let
     src = ./.;
     buildInputs = [ harvest-code pkgs.claude-code ] ++ agentRuntime;
     nativeBuildInputs = [ pkgs.makeWrapper ];
+    # cmake is only needed on the agent's runtime PATH (via makeBinPath below),
+    # not to build this wrapper. Suppress cmake's setup hook, which would
+    # otherwise try to cmake-configure our source (which has no CMakeLists.txt).
+    dontUseCmakeConfigure = true;
     installPhase = ''
       mkdir -p $out/bin
       cp $src/translate.sh $out/bin/translate-wrapper

--- a/translate.sh
+++ b/translate.sh
@@ -50,10 +50,21 @@ EOF
 # point them at test_case/. Inputs that already are the project (no test_case/
 # child, as in the older corpus) are used unchanged.
 src="$1"
+clar_cfg=""
 if [ -d "$src/test_case" ]; then
     src="$src/test_case"
     echo "translate-wrapper: input has a test_case/ child; translating '$src'." >&2
+    # June T&E experiment: if the parent also ships a clar test harness, hand the
+    # parent path to the verify stage so it can build and run those tests against
+    # the original C as a behavioral oracle (see verify_fix_agentic). The value
+    # has no spaces (container temp paths), so the unquoted expansion below is
+    # the intended two-argument split.
+    if [ -d "$1/tests" ]; then
+        clar_cfg="--config tools.verify_fix_agentic.clar_parent_dir=$1"
+        echo "translate-wrapper: clar tests present; enabling the verify oracle." >&2
+    fi
 fi
 
-translate --agentic --agentic-verify --agentic-agent claude -f -o "$2" "$src"
+# shellcheck disable=SC2086
+translate --agentic --agentic-verify --agentic-agent claude $clar_cfg -f -o "$2" "$src"
 chown -R "$newuid:$newgid" "$2"/*


### PR DESCRIPTION
## Why

Brings the container to the June T&E configuration: the agentic Claude pipeline with the provided clar tests wired in as a behavioral oracle for the verify stage.

## What

- **`default.nix`**
  - Pin `harvest-code` to the HARVEST `june-te` rev (`be32b79`), which adds the optional clar oracle to `verify_fix_agentic` (`clar_parent_dir`). This commit lives on HARVEST's `june-te` branch (the clar feature is kept off HARVEST `main` until a T&E run shows whether it helps); it is a public commit, so `fetchFromGitHub` resolves it by SHA.
  - Add `cmake`, `gnumake`, and `python3` to the agent runtime. The clar harness builds via CMake and its `generate.py` needs Python; these were also a latent gap for any CMake-based C build the agent attempts.
  - `dontUseCmakeConfigure = true` on the wrapper derivation: putting `cmake` in `buildInputs` activates cmake's setup hook, which would otherwise try to cmake-configure the wrapper's own source (no `CMakeLists.txt`) and fail the image build. cmake is only needed on the agent's runtime PATH.

- **`translate.sh`** — when the input is the T&E parent layout (a `test_case/` child) and a sibling `tests/` harness is present, pass `--config tools.verify_fix_agentic.clar_parent_dir=<parent>` so the verify stage materializes the parent and runs the clar tests against the original C as a behavioral oracle.

## Validation

- `docker build` succeeds on the `nixos/nix` base; the agent's wrapper PATH carries cmake 4.1.2, gnumake 4.4.1, python3 3.13.13, claude-code 2.1.154, cargo 1.95.0.
- In-container dry run (dummy key): the layout is detected (`clar tests present; enabling the verify oracle`) and the verify stage materializes the parent (`Materialized clar parent layout from /src`).
- The clar build recipe the verify prompt hands the agent runs clean against the C (host nix-shell: suite exit 0).
- A live key-authenticated run on `example_P02/config_tests` was exercised.

## Note

The clar oracle is used as a behavioral spec, never a Rust gate: the agent is told not to compile the clar tests against the Rust or reshape the translation (e.g. into a C-ABI cdylib) to satisfy them. Execution equivalence with the C remains the correctness criterion.