### PR TITLE
Bump harvest-code to june-te HEAD (translate-prompt completion fix)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,13 +11,14 @@
 
 let
   # The HARVEST translation binary. Pinned to the june-te branch (the June T&E
-  # experiment, which adds the optional clar test oracle) and built against the
-  # same pinned nixpkgs as everything else.
+  # experiment: the optional clar test oracle, plus the translate-prompt fix that
+  # makes the agent finish the whole codebase in one run instead of stopping at a
+  # foundation milestone). Built against the same pinned nixpkgs as everything else.
   harvest-code = import (pkgs.fetchFromGitHub {
     owner = "UW-HARVEST";
     repo = "harvest";
-    rev = "be32b794a95ff880533db4c46093d54165b6295c";
-    hash = "sha256-Sl6x1LUKNpnwVNiacg4s603gRw5YIaUXbHKdDuxS5Rg=";
+    rev = "80debd6aaa9e17e318fa078d80b1209543b4fdd4";
+    hash = "sha256-/Lh8VtZL4sAIFd6FQC5dxvth4RgQ6veU93fjjc6xnPw=";
   }) { inherit pkgs; };
 
   # Tools the agentic Claude agent invokes from its own shell while it builds


### PR DESCRIPTION
Pins `harvest-code` to `UW-HARVEST/harvest@80debd6` (the `june-te` branch HEAD), which adds the **translate-prompt completion fix** on top of the existing clar oracle.

## Why

The translate prompt's compaction-survival machinery (PLAN.md, "notes for future-me", "job ends at green build") was reading as a handoff to a future session, so on a large codebase the agent translated a foundation and **voluntarily stopped**. The fix adds an explicit mandate to translate the entire codebase in one run (a partial green build is a checkpoint, not completion) and tightens the done-criterion.

## Evidence (libgit2, ~162k LoC C)

- **Before:** one translate-only run stopped at **~14%** (util foundation only), voluntarily declaring a "multi-session effort".
- **After:** the same run reached **~64%** (104k LoC, green, deep into the recursive core) and stopped only because the external session usage limit was hit mid-translation -- not on the agent's own judgment.

## Change

`default.nix`: `harvest-code` rev `be32b79` -> `80debd6` + updated hash; comment updated. Eval verified.